### PR TITLE
Add basic layouts and homepage listing

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+<h1>{{ page.title }}</h1>
+<ul>
+{% assign posts = site.posts | sort: 'date' | reverse %}
+{% for post in posts %}
+  <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+{% endfor %}
+</ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+<h1>{{ page.title }}</h1>
+{{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+
+<article>
+  <h1>{{ page.title }}</h1>
+  <p><small>{{ page.date | date: "%B %-d, %Y" }}</small></p>
+  {{ content }}
+</article>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,4 @@
+---
+layout: home
+title: Home
+---


### PR DESCRIPTION
## Summary
- add layout templates for pages, posts, and home
- show list of all posts on new homepage
- create `index.md` to use home layout

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f5f6eba8832d8652a57236ab30a1