### PR TITLE
Fix YAML in category pages

### DIFF
--- a/category/bus-884-ethics-society-and-sustainability.md
+++ b/category/bus-884-ethics-society-and-sustainability.md
@@ -1,6 +1,6 @@
 ---
 layout: category
-title: BUS 884: Ethics, Society, and Sustainability
-category: BUS 884: Ethics, Society, and Sustainability
+title: "BUS 884: Ethics, Society, and Sustainability"
+category: "BUS 884: Ethics, Society, and Sustainability"
 permalink: /category/bus-884-ethics-society-and-sustainability/
 ---

--- a/category/tags.md
+++ b/category/tags.md
@@ -1,6 +1,6 @@
 ---
 layout: category
-title: tags:
-category: tags:
+title: tags
+category: tags
 permalink: /category/tags/
 ---

--- a/category/the-levels-challenge-build-12-startups-in-12-months.md
+++ b/category/the-levels-challenge-build-12-startups-in-12-months.md
@@ -1,6 +1,6 @@
 ---
 layout: category
-title: The Levels Challenge: Build 12 Startups in 12 Months
-category: The Levels Challenge: Build 12 Startups in 12 Months
+title: "The Levels Challenge: Build 12 Startups in 12 Months"
+category: "The Levels Challenge: Build 12 Startups in 12 Months"
 permalink: /category/the-levels-challenge-build-12-startups-in-12-months/
 ---


### PR DESCRIPTION
## Summary
- correct malformed YAML front matter in three category pages so GitHub Pages can build successfully

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852036b39d8832db9ba6a2e387b9234