### PR TITLE
Update homepage with category cards and all posts page

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,6 +10,7 @@
 
 <h2>Categories</h2>
 <ul>
+  <li><a href="/all-posts/">All Posts</a></li>
   {% assign sorted_categories = site.categories | sort %}
   {% for category in sorted_categories %}
     <li><a href="/category/{{ category[0] | slugify }}/">{{ category[0] }}</a></li>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+
+<h1>{{ page.title }}</h1>
+
+{% assign categories = "Featured,Adventures,Reading List,Essays" | split: "," %}
+{% for cat in categories %}
+<div class="card mb-4">
+  <div class="card-body">
+    <h3 class="card-title"><a href="/category/{{ cat | slugify }}/">{{ cat }}</a></h3>
+    <ul>
+      {% assign posts = site.categories[cat] | sort: 'date' | reverse | slice: 0, 10 %}
+      {% for post in posts %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+    <a href="/category/{{ cat | slugify }}/" class="card-link">View More</a>
+  </div>
+</div>
+{% endfor %}
+

--- a/all-posts.md
+++ b/all-posts.md
@@ -1,0 +1,5 @@
+---
+layout: home
+title: All Posts
+permalink: /all-posts/
+---

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
 ---
-layout: home
+layout: frontpage
 title: Home
 ---


### PR DESCRIPTION
## Summary
- add `frontpage` layout with Bootstrap category cards on Home
- show an 'All Posts' page listing every post
- link to All Posts in the sidebar categories list
- switch `index.md` to the new frontpage layout

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520f4c27e8832d9897f9acac5d474e