### PR TITLE
Fix Burning Man page & add 2025 burn post

### DIFF
--- a/_posts/2025-06-18-returning-to-the-burning.md
+++ b/_posts/2025-06-18-returning-to-the-burning.md
@@ -1,0 +1,19 @@
+---
+id: 16000
+title: "Returning To The Burning"
+date: '2025-06-18T00:00:00-08:00'
+author: cjtrowbridge
+layout: post
+guid: 'https://blog.cjtrowbridge.com/?p=16000'
+permalink: /2025/06/18/returning-to-the-burning/
+categories:
+    - '2025 Burn'
+    - Blog
+    - 'Burning Man'
+    - Projects
+tags:
+    - '2025 Burning Man'
+    - 'Burning Man'
+---
+
+After several years away, I'm finally returning to the playa. This post marks the beginning of planning for the 2025 burn.

--- a/burning-man.md
+++ b/burning-man.md
@@ -7,7 +7,17 @@ layout: page
 guid: 'https://blog.cjtrowbridge.com/?page_id=14122'
 ---
 
-<div>## [Burning Man!](/category/blog/projects/burning-man/)
+## Burning Man!
 
-<div>**2020 Burn: The Multiverse**![Burning Man 2020](https://blog.cjtrowbridge.com/wp-content/uploads/2019/10/Burning-Man-2020-1-1.jpg)[rpfc_recent_posts_from_category category="776" posts="10"]</div><div>**2019 Burn: Metamorphoses**![](https://blog.cjtrowbridge.com/wp-content/uploads/2020/12/2019-Temple-Burn-1-1.jpg)[rpfc_recent_posts_from_category category="773" posts="10"]</div><div>**2018 Burn: I, Robot**![](https://blog.cjtrowbridge.com/wp-content/uploads/2020/12/2018-Temple-1-1.jpg)</div><div>[rpfc_recent_posts_from_category category="745" posts="10"]</div><div>**2016 Burn: DaVinci's Workshop**</div><div>![](https://blog.cjtrowbridge.com/wp-content/uploads/2020/12/2016-Temple-Burn-1-1.jpg)</div><div>[rpfc_recent_posts_from_category category="774" posts="10"]</div><style>
-.rpfc-container ul{<br />  list-style-position: inside;<br />}<br /></style></div>
+{% assign burn_category_names = '2025 Burn|2020 Burn|2019 Burn|2018 Burn|2019 Burning Man|2018 Burning Man' | split: '|' %}
+{% for cat_name in burn_category_names %}
+  {% if site.categories[cat_name] %}
+### {{ cat_name }}
+  <ul>
+    {% assign posts = site.categories[cat_name] | sort: 'date' | reverse %}
+    {% for post in posts %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+{% endfor %}

--- a/category/2025-burn.md
+++ b/category/2025-burn.md
@@ -1,0 +1,6 @@
+---
+layout: category
+title: 2025 Burn
+category: 2025 Burn
+permalink: /category/2025-burn/
+---


### PR DESCRIPTION
## Summary
- replace old WordPress shortcodes on the Burning Man page with Jekyll loops
- add a new `2025 Burn` category
- create a new post for 2025 titled *Returning To The Burning*
- update Burning Man listing page to use an explicit set of year categories

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685213974db4832d90e5b9fc87fa43d9